### PR TITLE
Update versions (requirements, tox, pre-commit hooks)

### DIFF
--- a/.github/ISSUE_TEMPLATE/generic_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/generic_bug_report.yaml
@@ -16,7 +16,7 @@ body:
     options:
       - Layers
       - Activation functions
-      - Initializers 
+      - Initializers
       - Loss functions
       - Normalizers
   validations:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.3.0
     hooks:
     - id: trailing-whitespace
     - id: end-of-file-fixer
@@ -27,30 +27,30 @@ repos:
     - id: check-added-large-files
 
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.6.0
+    rev: v3.1.0
     hooks:
       - id: reorder-python-imports
 
   - repo: https://github.com/psf/black
-    rev: 21.6b0
+    rev: 22.3.0
     hooks:
     - id: black
 
   - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v3.0.0a3
+    rev: v3.0.0a5
     hooks:
       - id: pylint
         args: [--enable=unused-import --max-line-length=100, --disable=all]
 
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.20.0
+    rev: v2.27.1
     hooks:
       - id: commitizen
         stages: [commit-msg]
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.10
+    rev: v1.2.0
     hooks:
       - id: insert-license
         name: insert MIT license

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ work is not in vain.
 - Clone the repo `git clone https://github.com/deel-ai/deel-torchlip.git`.
 - Go to your freshly downloaded repo `cd deel-torchlip`
 - Create a virtual environment and install the necessary dependencies for development:
-  
+
   `make prepare-dev && source torchlip_dev_env/bin/activate`.
 - You are ready to install the library:
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -12,7 +12,7 @@ These management rules are intended to be collaborative and all those involved i
 
 The governance committee is initially composed of DEEL members who contributed to the first version of `deel-torchlip` and are the only contributors to the master branch.
 
-The governance committee is responsible for the master branch that contains the code of the version of the library that is officially recognised. 
+The governance committee is responsible for the master branch that contains the code of the version of the library that is officially recognised.
 
 These governance committee members are the only ones able to merge pull requests into this branch which from contributions branches.
 
@@ -22,13 +22,13 @@ The governance committee identifies among the contributors who by their merits c
 
 ###	Contributors
 
-A contributor is anyone who comments any aspects relating to the project: comments on an issue or pull request, documentation, architecture, code and validation tests or anybody with a merged pull request. 
+A contributor is anyone who comments any aspects relating to the project: comments on an issue or pull request, documentation, architecture, code and validation tests or anybody with a merged pull request.
 
 All governance committee membres are contributors.
 
 ### Maintainers
 
-All contributors with write rights (commit rigths) are maintainers.  
+All contributors with write rights (commit rigths) are maintainers.
 
 ....
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch_testing==0.0.2
 inflection==0.5.1
-numpy==1.19.5
+numpy
 torch==1.10.2+cu113
 torchvision==0.11.3+cu113

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,8 @@ pip_version = pip>=20
 deps =
     pytest
     torch_testing
-    torch==1.7.0+cpu
-    torchvision==0.8.1+cpu
+    torch==1.10.2+cu113
+    torchvision==0.11.3+cu113
 install_command = pip install --find-links https://download.pytorch.org/whl/torch_stable.html {opts} {packages}
 commands =
     pytest tests


### PR DESCRIPTION
Versions of packages in multiple files have been updated:
* NumPy 1.19.5 has a vulnerability and must be avoided (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-34141). The fixed version in `requirements.txt` is then removed to fetch the latest NumPy version.
* The tox virtual environments were fetching different torch/torchvision versions from the ones in `requirements.txt`. These versions are now aligned in both files to `torch==1.10.2+cu113` and `torchvision==0.11.3+cu113`.
* The pre-commit hooks have been updated to retrieve the latest versions up to date. Note that `black` hook 21.6b0 was broken: an update was mandatory.