### PR TITLE
New parameter "disjoint_neurons" in FrobeniusLinear

### DIFF
--- a/deel/torchlip/modules/conv.py
+++ b/deel/torchlip/modules/conv.py
@@ -170,7 +170,7 @@ class FrobeniusConv2d(torch.nn.Conv2d, LipschitzModule):
         if self.bias is not None:
             self.bias.data.fill_(0.0)
 
-        frobenius_norm(self, name="weight")
+        frobenius_norm(self, name="weight", disjoint_neurons=False)
         lconv_norm(self)
         self.register_forward_pre_hook(self._hook)
 

--- a/tests/test_lip_hook_norm.py
+++ b/tests/test_lip_hook_norm.py
@@ -65,7 +65,7 @@ def test_frobenius_norm():
     torch.nn.init.uniform_(m.weight)
     w1 = m.weight / torch.norm(m.weight)
 
-    frobenius_norm(m)
+    frobenius_norm(m, disjoint_neurons=False)
     assert not isinstance(m.weight, torch.nn.Parameter)
 
     x = torch.rand(2)
@@ -75,6 +75,21 @@ def test_frobenius_norm():
     remove_frobenius_norm(m)
     assert isinstance(m.weight, torch.nn.Parameter)
     tt.assert_equal(w1, m.weight)
+
+
+def test_frobenius_norm_disjoint_neurons():
+    """
+    Test `disjoint_neurons=True` parameter in frobenius_norm hook
+    """
+    m = torch.nn.Linear(in_features=5, out_features=3)
+
+    # Set hook and perform a forward pass to compute new weights
+    frobenius_norm(m, disjoint_neurons=True)
+    m(torch.rand(5))
+
+    # Assert that all rows of matrix weight are independently normalized
+    for i in range(m.out_features):
+        tt.assert_allclose(torch.norm(m.weight[i, :]), torch.tensor(1.0), rtol=2e-7)
 
 
 def test_lconv_norm():


### PR DESCRIPTION
So far, the `FrobeniusLinear` layer was offered to replace `SpectralLinear` when only one output neuron is used.
In this PR, a new parameter `disjoint_neurons` is introduced in `FrobeniusLinear` to handle multiple output neurons (like in deel-lip library): 
- if `disjoint_neurons = True`, each output neuron is 1-Lipschitz. It is equivalent to have multiple networks with a single output neuron.
- If `disjoint_neurons = False`, a Frobenius normalization is performed on the whole matrix weight.
