### PR TITLE
update tests and evaluate_lip_constant function

### DIFF
--- a/deel/torchlip/utils/__init__.py
+++ b/deel/torchlip/utils/__init__.py
@@ -66,7 +66,10 @@ def evaluate_lip_const(
 
     """
 
+    # Define a function that computes the model output
     def model_func(x):
+        # using vmap torchfunc method induce a single sample input
+        # so we need to unsqueeze the input
         y = model(torch.unsqueeze(x, dim=0))  # Forward pass
         return y
 

--- a/deel/torchlip/utils/__init__.py
+++ b/deel/torchlip/utils/__init__.py
@@ -30,7 +30,11 @@ Contains utility functions.
 from typing import Optional
 
 import torch
-import torch.func as tfc
+
+if torch.__version__.startswith("1."):
+    import functorch as tfc
+else:
+    import torch.func as tfc
 
 from .bjorck_norm import bjorck_norm
 from .bjorck_norm import remove_bjorck_norm
@@ -74,7 +78,6 @@ def evaluate_lip_const(
     # Reshape the Jacobian to match the desired shape
     batch_size = x.shape[0]
     xdim = torch.prod(torch.tensor(x.shape[1:])).item()
-    print(batch_jacobian.shape, x.shape)
     batch_jacobian = batch_jacobian.view(batch_size, -1, xdim)
 
     # Compute singular values and check Lipschitz property

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -213,9 +213,9 @@ def train_k_lip_model(
     test_dl = linear_generator(batch_size, input_shape, kernel)
     np.random.seed(42)
     uft.set_seed(42)
+    x, y = test_dl.send(None)
 
     loss, mse = uft.run_test(model, test_dl, loss_fn, metrics, steps=10)
-    x, y = test_dl.send(None)
 
     x = uft.to_tensor(x)
     empirical_lip_const = uft.evaluate_lip_const(model=model, x=x, seed=42)
@@ -235,10 +235,10 @@ def train_k_lip_model(
     np.random.seed(42)
     uft.set_seed(42)
     test_dl = linear_generator(batch_size, input_shape, kernel)  # .send(None)
+    x, y = test_dl.send(None)
     from_disk_loss, from_disk_mse = uft.run_test(
         model, test_dl, loss_fn, metrics, steps=10
     )
-    x, y = test_dl.send(None)
     x = uft.to_tensor(x)
     from_empirical_lip_const = uft.evaluate_lip_const(model=model, x=x, seed=42)
 
@@ -1316,10 +1316,10 @@ def test_SpectralConv1d_vanilla_export(
 
     # Test saving/loading model
     with tempfile.TemporaryDirectory() as tmpdir:
-        uft.MODEL_PATH = os.path.join(tmpdir, uft.MODEL_PATH)
-        uft.save_model(model, uft.MODEL_PATH, overwrite=True)
+        model_path = os.path.join(tmpdir, uft.MODEL_PATH)
+        uft.save_model(model, model_path, overwrite=True)
         uft.load_model(
-            uft.MODEL_PATH,
+            model_path,
             layer_type=layer_type,
             layer_params=layer_params,
             input_shape=input_shape,
@@ -1397,10 +1397,10 @@ def test_Conv2d_vanilla_export(pad, pad_mode, kernel_size, layer_params, layer_t
 
     # Test saving/loading model
     with tempfile.TemporaryDirectory() as tmpdir:
-        uft.MODEL_PATH = os.path.join(tmpdir, uft.MODEL_PATH)
-        uft.save_model(model, uft.MODEL_PATH, overwrite=True)
+        model_path = os.path.join(tmpdir, uft.MODEL_PATH)
+        uft.save_model(model, model_path, overwrite=True)
         uft.load_model(
-            uft.MODEL_PATH,
+            model_path,
             layer_type=layer_type,
             layer_params=layer_params,
             input_shape=input_shape,
@@ -1448,10 +1448,10 @@ def test_SpectralConvTranspose2d_vanilla_export():
 
     # Test saving/loading model
     with tempfile.TemporaryDirectory() as tmpdir:
-        uft.MODEL_PATH = os.path.join(tmpdir, uft.MODEL_PATH)
-        uft.save_model(model, uft.MODEL_PATH, overwrite=True)
+        model_path = os.path.join(tmpdir, uft.MODEL_PATH)
+        uft.save_model(model, model_path, overwrite=True)
         uft.load_model(
-            uft.MODEL_PATH,
+            model_path,
             layer_type=SpectralConvTranspose2d,
             layer_params=kwargs,
             input_shape=kwargs["input_shape"],

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -77,6 +77,7 @@ def check_serialization(nb_class, loss):
     )
     name = loss.__class__.__name__ if isinstance(loss, Loss) else loss.__name__
     path = os.path.join("logs", "losses", name)
+
     uft.save_model(m, path)
     m2 = uft.load_model(
         path,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -101,7 +101,8 @@ def test_serialization(nb_class, loss, loss_params, nb_classes):
 
     l1 = m.evaluate(x, y)
     name = loss.__class__.__name__
-    path = os.path.join("logs", "losses", name)
+    path = os.path.join("logs", "metrics", name)
+
     uft.save_model(m, path)
     m2 = uft.load_model(
         path,

--- a/tests/test_pooling.py
+++ b/tests/test_pooling.py
@@ -235,7 +235,6 @@ def test_AvgPooling(layer_type, layer_params, expected):
     xnp = np.asarray(input)
     xnp = uft.to_NCHW_inv(xnp)  # move channel if needed (TF)
     x = uft.to_tensor(xnp)
-    print(x.shape)
     uft.build_layer(pool, x.shape[1:])
 
     y = pool(x).numpy()


### PR DESCRIPTION
* Modify some tests for compatibility with tf and keras3
* Change the evaluate_lip_constant function to use the jacobian and functorch (due to precision errors of the previous evaluation method with $||f(x+dx)-f(x)||/||dx||$)